### PR TITLE
Use stepInfo.outputLocation to determine if pipeline steps are persisted

### DIFF
--- a/src/main/scala/org/allenai/pipeline/Pipeline.scala
+++ b/src/main/scala/org/allenai/pipeline/Pipeline.scala
@@ -24,12 +24,13 @@ trait Pipeline extends Logging {
 
   def run(rawTitle: String, outputs: Producer[_]*): Unit = {
     try {
+      val outputInfo = outputs.map(_.stepInfo)
       require(
-        outputs.forall(_.isInstanceOf[PersistedProducer[_, _]]),
+        outputInfo.forall(_.outputLocation.isDefined),
         s"Running a pipeline without persisting the output: ${
-          outputs.filter(p => !p
-            .isInstanceOf[PersistedProducer[_, _]]).map(_.stepInfo.className).mkString(",")
-        }}"
+          outputInfo.filter(_.outputLocation.isEmpty)
+            .map(_.className).mkString(",")
+        }"
       )
 
       val start = System.currentTimeMillis

--- a/src/main/scala/org/allenai/pipeline/Producer.scala
+++ b/src/main/scala/org/allenai/pipeline/Producer.scala
@@ -1,6 +1,6 @@
 package org.allenai.pipeline
 
-import org.allenai.common.{Logging, Timing}
+import org.allenai.common.{ Logging, Timing }
 
 import scala.concurrent.duration.Duration
 
@@ -142,9 +142,9 @@ trait CachingDisabled extends CachingEnabled {
 }
 
 class PersistedProducer[T, -A <: Artifact](
-  step: Producer[T],
-  io: SerializeToArtifact[T, A] with DeserializeFromArtifact[T, A],
-  _artifact: A
+    step: Producer[T],
+    io: SerializeToArtifact[T, A] with DeserializeFromArtifact[T, A],
+    _artifact: A
 ) extends Producer[T] {
   self =>
 


### PR DESCRIPTION
A more robust check on whether a pipeline is being run without persisting all of its outputs
