### PR TITLE
test_only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,6 @@ libraryDependencies ++= Seq(
   awsJavaSdk,
   commonsIO,
   ai2Common,
-  allenAiTestkit,
+  allenAiTestkit % "test",
   scalaReflection
 )


### PR DESCRIPTION
Pull testkit only for test.
This transitively pulls wrong akka version in s2-offline, so spark shell is broken once more.
