### PR TITLE
Add Pipeline.runOnly()

### DIFF
--- a/src/main/scala/org/allenai/pipeline/Pipeline.scala
+++ b/src/main/scala/org/allenai/pipeline/Pipeline.scala
@@ -342,3 +342,10 @@ trait ConfiguredPipeline extends Pipeline {
   }
 
 }
+
+object ConfiguredPipeline {
+  def apply(cfg: Config): ConfiguredPipeline =
+    new ConfiguredPipeline {
+      val config = cfg
+    }
+}

--- a/src/main/scala/org/allenai/pipeline/Pipeline.scala
+++ b/src/main/scala/org/allenai/pipeline/Pipeline.scala
@@ -54,13 +54,11 @@ trait Pipeline extends Logging {
         if !overridenStepsInfo(pp.stepInfo)
         if !pp.artifact.exists
       } yield pp.stepInfo
-    require(
-      nonExistentDependencies.size == 0,
-      s"""
-         |Cannot run steps [${overridenStepsInfo.map(_.className).mkString(",")}].
-                                                                                  |Upstream dependencies [${nonExistentDependencies.map(_.className).mkString(",")}] have not been computed)
-                                                                                                                                                                     |""".stripMargin
-    )
+    require(nonExistentDependencies.size == 0, {
+      val targetNames = overridenStepsInfo.map(_.className).mkString(",")
+      val dependencyNames = nonExistentDependencies.map(_.className).mkString(",")
+      s"Cannot run steps [$targetNames]. Upstream dependencies [$dependencyNames] have not been computed"
+    })
     run(title, targets)
   }
 

--- a/src/main/scala/org/allenai/pipeline/Workflow.scala
+++ b/src/main/scala/org/allenai/pipeline/Workflow.scala
@@ -155,6 +155,11 @@ object Workflow {
     Workflow(nodes, links)
   }
 
+  def upstreamDependencies(step: PipelineStep): Set[PipelineStep] = {
+    val parents = step.stepInfo.dependencies.map(_._2).toSet
+    parents ++ parents.flatMap(upstreamDependencies)
+  }
+
   implicit val jsFormat = {
     implicit val linkFormat = jsonFormat3(Link)
     implicit val nodeFormat = {

--- a/src/test/scala/org/allenai/pipeline/SamplePipeline.scala
+++ b/src/test/scala/org/allenai/pipeline/SamplePipeline.scala
@@ -53,7 +53,7 @@ class SamplePipeline extends UnitSpec
     val model = pipeline.Persist.Singleton.asJson(new TrainModel(trainDataPersisted), None, ".json")
     val measure: Producer[PRMeasurement] =
       pipeline.Persist.Collection.asText(new MeasureModel(model, testData), None, ".txt")
-    pipeline.run("SamplePipeline", measure)
+    pipeline.run("SamplePipeline")
 
     assert(findFile(outputDataDir, "JoinAndSplitData_train", ".txt"), "Training data file created")
     assert(findFile(outputDataDir, "TrainModel", ".json"), "Json file created")
@@ -77,7 +77,7 @@ class SamplePipeline extends UnitSpec
     val model = pipeline.Persist.Singleton.asJson(new TrainModel(trainDataPersisted), None, ".json")
     val measure =
       pipeline.Persist.Collection.asText(new MeasureModel(model, testData), None, ".txt")
-    val experimentSummary = pipeline.run("Sample Experiment", measure)
+    val experimentSummary = pipeline.run("Sample Experiment")
 
     val trainDataFile = new File(trainDataPersisted.artifact.url)
     val measureFile = new File(measure.artifact.url)
@@ -100,7 +100,7 @@ class SamplePipeline extends UnitSpec
       ), None, ".json")
       val measure: PersistedProducer[PRMeasurement, FlatArtifact] =
         pipeline.Persist.Collection.asText(new MeasureModel(model, testData))
-      pipeline.run("SamplePipeline", measure)
+      pipeline.run("SamplePipeline")
       (new File(trainDataPersisted.artifact.url),
         new File(measure.artifact.url))
     }
@@ -269,7 +269,7 @@ object SamplePipelineApp extends App with Pipeline {
   val model = Persist.Singleton.asJson(new TrainModel(trainDataPersisted), None, ".json")
   val measure: Producer[PRMeasurement] =
     Persist.Collection.asText(new MeasureModel(model, testData), None, ".txt")
-  run("Sample Pipeline", measure)
+  run("Sample Pipeline")
 
   println(s"Pipeline files written to ${outputDir.getAbsolutePath}")
 }

--- a/src/test/scala/org/allenai/pipeline/TestConfiguredPipeline.scala
+++ b/src/test/scala/org/allenai/pipeline/TestConfiguredPipeline.scala
@@ -1,0 +1,101 @@
+package org.allenai.pipeline
+
+import java.io.File
+
+import com.typesafe.config.{ ConfigValueFactory, ConfigValue, ConfigFactory }
+import org.allenai.common.testkit.{ ScratchDirectory, UnitSpec }
+import spray.json.pimpAny
+
+/** Created by rodneykinney on 5/12/15.
+  */
+class TestConfiguredPipeline extends UnitSpec with ScratchDirectory {
+  val baseConfig = ConfigFactory.load()
+    .withValue("output.persist.Step2", ConfigValueFactory.fromAnyRef("Step2Output.txt"))
+    .withValue("output.persist.Step3", ConfigValueFactory.fromAnyRef("Step3Output.txt"))
+
+  val step1 = new Producer[Int] with Ai2SimpleStepInfo {
+    override def create = 1
+  }
+  case class AddOne(p: Producer[Int]) extends Producer[Int] with Ai2StepInfo {
+    override def create = 1 + p.get
+  }
+
+  import IoHelpers._
+
+  val format = SingletonIo.text[Int]
+
+  it should "optionally persist" in {
+    val outputDir = new File(scratchDir, "testOptionallyPersist")
+    val pipeline = ConfiguredPipeline(
+      baseConfig
+        .withValue("output.dir", ConfigValueFactory.fromAnyRef(outputDir.getCanonicalPath))
+    )
+    pipeline.optionallyPersist(AddOne(step1), "Step2", format)
+
+    pipeline.run("test")
+
+    new File(outputDir, "data/Step2Output.txt") should exist
+  }
+
+  it should "recognize dryRun flag" in {
+    val outputDir = new File(scratchDir, "testDryRun")
+    val pipeline = ConfiguredPipeline(
+      baseConfig
+        .withValue("output.dir", ConfigValueFactory.fromAnyRef(outputDir.getCanonicalPath))
+        .withValue("dryRun", ConfigValueFactory.fromAnyRef(true))
+    )
+    pipeline.optionallyPersist(AddOne(step1), "Step2", format)
+
+    pipeline.run("test")
+
+    new File(outputDir, "data/Step2Output.xt") should not(exist)
+  }
+
+  it should "recognize runOnly flag" in {
+    val outputDir = new File(scratchDir, "testRunOnly")
+    val config = baseConfig
+      .withValue("output.dir", ConfigValueFactory.fromAnyRef(outputDir.getCanonicalPath))
+      .withValue("runOnly", ConfigValueFactory.fromAnyRef("Step3"))
+
+    // config specifies runOnly for step3 with no persisted upstream dependencies
+    val pipeline = ConfiguredPipeline(config)
+    val step2 = AddOne(step1)
+    pipeline.optionallyPersist(AddOne(step2), "Step3", format)
+    pipeline.run("test")
+
+    new File(outputDir, "data/Step3Output.txt") should exist
+  }
+
+  it should "recognize runOnly flag and fail if upstream dependencies don't exist" in {
+    val outputDir = new File(scratchDir, "testRunOnly2")
+    val config = baseConfig
+      .withValue("output.dir", ConfigValueFactory.fromAnyRef(outputDir.getCanonicalPath))
+      .withValue("runOnly", ConfigValueFactory.fromAnyRef("Step3"))
+
+    // config specifies runOnly for step3 but step2 is not persisted
+    an[IllegalArgumentException] should be thrownBy {
+      val pipeline = ConfiguredPipeline(config)
+      val step2 = pipeline.optionallyPersist(AddOne(step1), "Step2", format)
+      pipeline.optionallyPersist(AddOne(step2), "Step3", format)
+      pipeline.run("test")
+    }
+  }
+
+  it should "recognize tempOutputDir flag" in {
+    val outputDir = new File(scratchDir, "testRunOnly3")
+    val tempOutput = new File(outputDir, "temp-output")
+    val config = baseConfig
+      .withValue("output.dir", ConfigValueFactory.fromAnyRef(outputDir.getCanonicalPath))
+      .withValue("runOnly", ConfigValueFactory.fromAnyRef("Step3"))
+      .withValue("tempOutput", ConfigValueFactory.fromAnyRef(tempOutput.getCanonicalPath))
+
+    // config specifies runOnly for step3 with no persisted upstream dependencies
+    val pipeline = ConfiguredPipeline(config)
+    val step2 = AddOne(step1)
+    pipeline.optionallyPersist(AddOne(step2), "Step3", format)
+    pipeline.run("test")
+
+    new File(outputDir, "data/Step3Output.txt") should not(exist)
+    new File(tempOutput, "data/Step3Output.txt") should exist
+  }
+}

--- a/src/test/scala/org/allenai/pipeline/TestConfiguredPipeline.scala
+++ b/src/test/scala/org/allenai/pipeline/TestConfiguredPipeline.scala
@@ -87,7 +87,7 @@ class TestConfiguredPipeline extends UnitSpec with ScratchDirectory {
     val config = baseConfig
       .withValue("output.dir", ConfigValueFactory.fromAnyRef(outputDir.getCanonicalPath))
       .withValue("runOnly", ConfigValueFactory.fromAnyRef("Step3"))
-      .withValue("tempOutput", ConfigValueFactory.fromAnyRef(tempOutput.getCanonicalPath))
+      .withValue("tmpOutput", ConfigValueFactory.fromAnyRef(tempOutput.getCanonicalPath))
 
     // config specifies runOnly for step3 with no persisted upstream dependencies
     val pipeline = ConfiguredPipeline(config)

--- a/src/test/scala/org/allenai/pipeline/TestPipeline.scala
+++ b/src/test/scala/org/allenai/pipeline/TestPipeline.scala
@@ -1,0 +1,91 @@
+package org.allenai.pipeline
+
+import java.io.File
+
+import org.allenai.common.testkit.{ ScratchDirectory, UnitSpec }
+
+class TestPipeline extends UnitSpec with ScratchDirectory {
+  "Pipeline" should "run all persisted targets" in {
+    val p1 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 1
+    }
+    val p2 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 2
+    }
+    val p3 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 3
+    }
+    val p4 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 4
+    }
+    val outputDir = new File(scratchDir, "test1")
+    val pipeline = new Pipeline {
+      val artifactFactory = new RelativeFileSystem(outputDir)
+    }
+
+    import IoHelpers._
+    val format = SingletonIo.text[Int]
+    pipeline.persist(p1, format, Some("prod1"))
+    pipeline.persist(p2, format, Some("prod2"))
+    pipeline.persist(p3, format, Some("prod3"))
+    val p4Persisted = pipeline.persist(p4, format, Some("prod4"))
+
+    an[IllegalArgumentException] should be thrownBy {
+      val p5 = new Producer[Int] with Ai2SimpleStepInfo {
+        override def create = 5
+        override def stepInfo = super.stepInfo.addParameters(("upstream", p4Persisted))
+      }
+      pipeline.persist(p5, format, Some("prod5"))
+      // p5 has p4 as a dependency, but p4 has not been computed yet
+      pipeline.runOnly("test", p5)
+    }
+
+    pipeline.runOnly("test", p1)
+    new File(outputDir, "data/prod1") should exist
+    new File(outputDir, "data/prod2") should not(exist)
+
+    pipeline.run("test")
+    new File(outputDir, "data/prod2") should exist
+    new File(outputDir, "data/prod3") should exist
+    new File(outputDir, "data/prod4") should exist
+
+    an[IllegalArgumentException] should be thrownBy {
+      val p5 = new Producer[Int] with Ai2SimpleStepInfo {
+        override def create = 5
+      }
+      // p5 has not been persisted, so we should not specify it as an output
+      pipeline.runOnly("test", p5)
+    }
+
+    val p5 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 5
+      override def stepInfo = super.stepInfo.addParameters(("upstream", p4))
+    }
+    pipeline.persist(p5, format, Some("prod5"))
+    // p5 is persisted and its dependency exists.  All clear!
+    pipeline.runOnly("test", p5)
+  }
+
+  "Pipeline" should "respect both relative and absolute persistence paths" in {
+    val p1 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 1
+    }
+    val p2 = new Producer[Int] with Ai2SimpleStepInfo {
+      override def create = 2
+    }
+
+    val outputDir = new File(scratchDir, "test2")
+    val pipeline = new Pipeline {
+      val artifactFactory = new RelativeFileSystem(outputDir)
+    }
+
+    import IoHelpers._
+    val format = SingletonIo.text[Int]
+    pipeline.persist(p1, format, Some("prod1"))
+    pipeline.persist(p2, format, Some(s"file://$scratchDir/absolute-path/prod2"))
+
+    pipeline.run("test")
+    new File(scratchDir, "absolute-path/prod2") should exist
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.4-SNAPSHOT"
+version in ThisBuild := "1.1.3-1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.3-1"
+version in ThisBuild := "1.1.4-0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.4-0-SNAPSHOT"
+version in ThisBuild := "1.2.0-SNAPSHOT"


### PR DESCRIPTION
Three changes:
- `Pipeline.run()` takes no Producer arguments.  Instead, all Producers that have been persisted via `Pipeline.persist()` will be run
- Add `Pipeline.runOnly()` which takes a list of Producers as arguments, and throws an exception if any upstream dependencies are not found on disk
- Allow for absolute URLs in `Pipeline.persist()`.  This will allow you to test a component by reading upstream dependencies from S3 but saving your own output to the local filesystem.

@jakemannix @vha14 FYI

Example command lines in s2 pipeline:

```
$ # Run locally.
$ sbt "project pipeline" ; set javaOptions ++= Seq("-Dspark-pipeline.runOnly=matching","-Dspark-pipeline.tmpOutput=file:///tmp/cristipp","-Dconfig.resource=static/acl/build-index.conf") ; "runMain org.allenai.scholar.pipeline.spark.BuildIndexFromPdfs

$ # Run on an existing cluster.
$ cluster.sh pipeline start org.allenai.scholar.pipeline.spark.BuildIndexFromPdfs spark-pipeline.runOnly=matching spark-pipeline.tmpOutput=file:///tmp/cristipp config.resource=static/acl/build-index.conf
```

Edit2: Even better, all this works from the sbt console, no need to muck with command line arguments just yet:

```
$ sbt "project pipeline" console
scala> import org.allenai.scholar.pipeline.spark._
scala> val pipeline = new BuildIndexFromPdfsPipeline("build-index/acl.conf")  
scala> val matching = pipeline.runOnly("matching", ...)
scala> SimpleMatch.recall(matching).recall
res0: Double = 0.6828287105653187
```
