### PR TITLE
Upgrade plugins, use provided semantic versioning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,19 +31,6 @@ pomExtra := (
 // Enable the LibraryPlugin for release workflow support
 enablePlugins(LibraryPlugin)
 PublishTo.ai2Public
-// We need to override the default versioning scheme provided by the LibraryPlugin
-// because we want to Use semantic versioning for public releases.
-// TODO(markschaake|?): enhance the org.allenai.plugins.ReleasePlugin to make it simple
-// to switch between versioning schemes.
-// These overrides are copied from the underlying sbt-release plugin's sources for default
-// semantic version.
-// See: https://github.com/sbt/sbt-release/blob/master/src/main/scala/ReleasePlugin.scala
-nextVersion <<= (versionBump) { bumpType: sbtrelease.Version.Bump =>
-  ver => sbtrelease.Version(ver).map(_.bump(bumpType).asSnapshot.string).getOrElse(sbtrelease.versionFormatError)
-}
-releaseVersion := { ver =>
-  sbtrelease.Version(ver).map(_.withoutQualifier.string).getOrElse(sbtrelease.versionFormatError)
-}
 
 dependencyOverrides += "org.scala-lang" % "scala-reflect" % "2.11.5"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "2015.02.16-0")
+addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "2015.05.29-0")


### PR DESCRIPTION
@rodneykinney this will unblock s2 from upgrading to latest plugins which include bugfix releases for spray and spray-json. See my comment in https://github.com/allenai/scholar/issues/396.

After a new version is released, I'll need to update the plugins again with the latest version of pipeline.

Also, I won't upgrade S2 repo until milestone craziness is done, so don't worry about that :)
