### PR TITLE
Bump version

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2-SNAPSHOT"
+version in ThisBuild := "1.2.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2"
+version in ThisBuild := "1.2.3-SNAPSHOT"


### PR DESCRIPTION
Turns out the last PR was set to publish to version 1.2.1 - which already exists! Wonder how that happened. Anyway, this PR should actually publish and now to version 1.2.2.
