### PR TITLE
Bump aws-java-sdk version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import org.allenai.plugins.CoreDependencies
 
 /** Object holding the dependencies Common has, plus resolvers and overrides. */
 object Dependencies extends CoreDependencies {
-  val awsJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.8.9.1"
+  val awsJavaSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.9.40"
   val scalaReflection = "org.scala-lang" % "scala-reflect" % "2.11.5"
   val commonsIO = "commons-io" % "commons-io" % "2.4"
   val ai2Common = allenAiCommon exclude ("org.allenai", "pipeline")


### PR DESCRIPTION
@markschaake This was the source of my compile error.  They broke up aws-java-sdk into multiple projects.
