### PR TITLE
Pipeline.map lifting

### DIFF
--- a/src/test/scala/org/allenai/pipeline/TestProducer.scala
+++ b/src/test/scala/org/allenai/pipeline/TestProducer.scala
@@ -45,6 +45,13 @@ class TestProducer extends UnitSpec with ScratchDirectory {
     cached.get should equal(cached.get)
   }
 
+  "Producer" should "should support map" in {
+    val producer = Producer.fromMemory(Seq(1,2,3,4))
+    val sumProducer = producer.map("SumNums",(xs: Seq[Int]) => xs.sum)
+    sumProducer.get shouldBe 10
+    sumProducer.stepInfo.className shouldBe "SumNums"
+  }
+
   "PersistedProducer" should "read from file if exists" in {
     val pStep = pipeline.Persist.Collection.asText(randomNumbers)
 


### PR DESCRIPTION
Provide a way to call `.map` to make a new `Producer` that preserves the options on the parent `PipelineStepInfo` but can override the step-name. There's also an overloaded version which will let you fully customize the step-info.

This should allow us to simplify code which processes `Producer`s so that you can just write a function that transforms the underlying objects (which are easier to test) and then just `.map` to get the new producer. 

FYI /cc @jakemannix @vha14 @schmmd 
