### PR TITLE
Release 1.4.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.1"
+version in ThisBuild := "1.4.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.1-SNAPSHOT"
+version in ThisBuild := "1.4.1"


### PR DESCRIPTION
Looks like I cut v1.4.0 from a commit that was behind HEAD. This should be up-to-date.

@markschaake 
