### PR TITLE
Compressed S3 artifact

### DIFF
--- a/src/main/scala/org/allenai/pipeline/FileArtifact.scala
+++ b/src/main/scala/org/allenai/pipeline/FileArtifact.scala
@@ -31,7 +31,7 @@ class FileArtifact(val file: File) extends FlatArtifact {
   // Note:  The write operation is atomic.  The file is only created if the write operation
   // completes successfully
   def write[T](writer: ArtifactStreamWriter => T): T = {
-    val tmpFile = File.createTempFile(file.getName, "tmp", parentDir)
+    val tmpFile = File.createTempFile(file.getName, ".tmp", parentDir)
     tmpFile.deleteOnExit()
     val result = Resource.using(new FileOutputStream(tmpFile)) {
       fileOut => writer(new ArtifactStreamWriter(fileOut))
@@ -48,7 +48,7 @@ class CompressedFileArtifact(file: File) extends FileArtifact(file) {
   override def read: InputStream = new BZip2CompressorInputStream(new FileInputStream(file))
 
   override def write[T](writer: ArtifactStreamWriter => T): T = {
-    val tmpFile = File.createTempFile(file.getName, "tmp", parentDir)
+    val tmpFile = File.createTempFile(file.getName, ".tmp", parentDir)
     tmpFile.deleteOnExit()
     val result = Resource.using(new BZip2CompressorOutputStream(new FileOutputStream(tmpFile))) {
       fileOut => writer(new ArtifactStreamWriter(fileOut))
@@ -176,7 +176,7 @@ class ZipFileArtifact(val file: File) extends StructuredArtifact {
       (parentDir.exists && parentDir.isDirectory) || parentDir.mkdirs,
       s"Unable to find or create directory $parentDir"
     )
-    private val tmpFile = File.createTempFile(file.getName, "tmp", parentDir)
+    private val tmpFile = File.createTempFile(file.getName, ".tmp", parentDir)
     tmpFile.deleteOnExit()
     private val zipOut = new ZipOutputStream(new FileOutputStream(tmpFile))
     private val out = new ArtifactStreamWriter(zipOut)

--- a/src/main/scala/org/allenai/pipeline/FileArtifact.scala
+++ b/src/main/scala/org/allenai/pipeline/FileArtifact.scala
@@ -110,7 +110,7 @@ class DirectoryArtifact(val dir: File) extends StructuredArtifact {
     val dirWriter = new Writer {
       def writeEntry[T2](name: String)(writer: ArtifactStreamWriter => T2): T2 = {
         val outFile = new File(tmpDir, name)
-        require(outFile.getParentFile == null || outFile.getParentFile.exists || outFile.getParentFile.mkdirs(), "Cannot create file $outFile")
+        require(outFile.getParentFile == null || outFile.getParentFile.exists || outFile.getParentFile.mkdirs(), s"Cannot create file $outFile")
         val out = new FileOutputStream(outFile)
         val result = writer(new ArtifactStreamWriter(out))
         out.close()

--- a/src/main/scala/org/allenai/pipeline/s3/S3Artifact.scala
+++ b/src/main/scala/org/allenai/pipeline/s3/S3Artifact.scala
@@ -167,9 +167,6 @@ trait CompressedS3Artifact extends S3Artifact {
   override def readContents(): InputStream = new BZip2CompressorInputStream(super.readContents())
 }
 
-object CompressedS3Artifact {
-}
-
 /** Implements policy for making local caches of artifacts in S3
   */
 trait S3Cache {


### PR DESCRIPTION
@rodneykinney, I think this is a better implementation. Instead of keeping the compression setting in the LocalS3Cache (which was broken, by the way), this keeps it in the artifact. So you can use compressed or uncompressed artifacts with the same cache, but more importantly, the compress and uncompress functions are really close to each other. I find this design much cleaner than the previous one, especially when considering the fixes it would have needed.
