### PR TITLE
Cache signature id, use better hash

### DIFF
--- a/src/main/scala/org/allenai/pipeline/ArtifactIo.scala
+++ b/src/main/scala/org/allenai/pipeline/ArtifactIo.scala
@@ -53,7 +53,7 @@ class SingletonIo[T: StringSerializable: ClassTag](implicit codec: Codec)
     _.write(implicitly[StringSerializable[T]].toString(data))
   }
 
-  override def stepInfo: PipelineStepInfo = {
+  override val stepInfo: PipelineStepInfo = {
     val className = scala.reflect.classTag[T].runtimeClass.getSimpleName
     super.stepInfo.copy(
       className = s"ReadObject[$className]",
@@ -84,7 +84,7 @@ class LineCollectionIo[T: StringSerializable: ClassTag](implicit codec: Codec)
   override def write(data: Iterable[T], artifact: FlatArtifact): Unit =
     delegate.write(data.iterator, artifact)
 
-  override def stepInfo: PipelineStepInfo = {
+  override val stepInfo: PipelineStepInfo = {
     val className = scala.reflect.classTag[T].runtimeClass.getSimpleName
     super.stepInfo.copy(
       className = s"ReadCollection[$className]",
@@ -129,7 +129,7 @@ class LineIteratorIo[T: StringSerializable: ClassTag](implicit codec: Codec)
     }
   }
 
-  override def stepInfo: PipelineStepInfo = {
+  override val stepInfo: PipelineStepInfo = {
     val className = scala.reflect.classTag[T].runtimeClass.getSimpleName
     super.stepInfo.copy(
       className =

--- a/src/main/scala/org/allenai/pipeline/DirectoryIo.scala
+++ b/src/main/scala/org/allenai/pipeline/DirectoryIo.scala
@@ -24,5 +24,5 @@ object DirectoryIo extends ArtifactIo[Map[String, String], StructuredArtifact] {
     }).toMap
   }
 
-  override def stepInfo: PipelineStepInfo = PipelineStepInfo("SaveDirectory")
+  override val stepInfo: PipelineStepInfo = PipelineStepInfo("SaveDirectory")
 }

--- a/src/main/scala/org/allenai/pipeline/Producer.scala
+++ b/src/main/scala/org/allenai/pipeline/Producer.scala
@@ -141,7 +141,7 @@ object Producer {
   def fromMemory[T](data: T): Producer[T] = new Producer[T] with BasicPipelineStepInfo {
     override def create: T = data
 
-    override def stepInfo: PipelineStepInfo =
+    override val stepInfo: PipelineStepInfo =
       super.stepInfo.copy(
         className = data.getClass.getName,
         classVersion = data.hashCode.toHexString

--- a/src/test/scala/org/allenai/pipeline/TestProducer.scala
+++ b/src/test/scala/org/allenai/pipeline/TestProducer.scala
@@ -178,21 +178,21 @@ class TestProducer extends UnitSpec with ScratchDirectory {
   }
 
   val prs6withDep = new PipelineStep {
-    override def stepInfo: PipelineStepInfo = base.addParameters("param1" -> 4, "upstream" -> prs1)
+    override val stepInfo: PipelineStepInfo = base.addParameters("param1" -> 4, "upstream" -> prs1)
   }
   val prs6withSomeDep = new PipelineStep {
-    override def stepInfo: PipelineStepInfo =
+    override val stepInfo: PipelineStepInfo =
       base.addParameters("param1" -> 4, "upstream" -> Some(prs1))
   }
   val prs6withSomeOtherDepSameSig = new PipelineStep {
-    override def stepInfo: PipelineStepInfo =
+    override val stepInfo: PipelineStepInfo =
       base.addParameters("param1" -> 4, "upstream" -> Some(prs1a))
   }
   val prs6withNoneDep = new PipelineStep {
-    override def stepInfo: PipelineStepInfo = base.addParameters("param1" -> 4, "upstream" -> None)
+    override val stepInfo: PipelineStepInfo = base.addParameters("param1" -> 4, "upstream" -> None)
   }
   val prs6withoutDep = new PipelineStep {
-    override def stepInfo: PipelineStepInfo = base.addParameters("param1" -> 4)
+    override val stepInfo: PipelineStepInfo = base.addParameters("param1" -> 4)
   }
   "Signature with Option[Producer]" should "have the same signature as with just same Producer" in {
     prs6withDep.stepInfo.signature.id should equal(prs6withSomeDep.stepInfo.signature.id)


### PR DESCRIPTION
This change caches the hashcode for a pipeline step in a local variable. Speeds up dry runs dramatically.

To get the full speedup, you also need to cache the stepInfo of each Producer.

I tested a pipeline dry run with this version of the pipeline library, and it took just a few seconds, compared with about 10 minutes previously.

@dirkgr FYI
