### PR TITLE
Don't overwrite executionMode

### DIFF
--- a/src/main/scala/org/allenai/pipeline/ExecutionInfo.scala
+++ b/src/main/scala/org/allenai/pipeline/ExecutionInfo.scala
@@ -27,7 +27,8 @@ trait ExecutionInfo {
 /** The Producer was not needed to run the pipeline.
   * (All downstream steps were already persisted)
   */
-case object NotRequested extends ExecutionInfo {
+case object NotRequested extends Function1[Duration, ExecutionInfo] with ExecutionInfo {
+  override def apply(duration: Duration) = this
   override def status = "Not requested"
 }
 


### PR DESCRIPTION
If a Producer is consumed twice (and not cached in memory), its status was being overwritten to "Read" the second time it was accessed. This change preserves the ExectionInfo from the first access.
